### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ kind: Service
 metadata:
   name: goldpinger
   namespace: default
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '8080'
   labels:
     app: goldpinger
 spec:


### PR DESCRIPTION
If you have Prometheus in your environment, adding these annotation will let  Prometheus auto-discovery fetch your metrics automatically from service-name:port/metrics