### PR TITLE
tolerate master nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ spec:
         app: goldpinger
     spec:
       serviceAccount: "goldpinger-serviceaccount"
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
Kubernetes master node by most of default installation are taint, so goldPinger DaemonSet will not deployed to master, in order to make it run on master nodes also, you have to tolerate the taint